### PR TITLE
アイコンクリックでオプションページを開くように

### DIFF
--- a/nico_downloader/icon_clicked.js
+++ b/nico_downloader/icon_clicked.js
@@ -1,0 +1,4 @@
+// icon_clicked.js
+chrome.action.onClicked.addListener(() => {
+    chrome.runtime.openOptionsPage();
+});

--- a/nico_downloader/manifest.json
+++ b/nico_downloader/manifest.json
@@ -50,5 +50,9 @@
             ]
         }
     ],
+    "background": {
+        "service_worker": "icon_clicked.js"
+    },
+    "action":{},
     "options_page": "options.html"
 }

--- a/nico_downloader/manifest.json
+++ b/nico_downloader/manifest.json
@@ -9,7 +9,8 @@
         "128": "icon_128.png"
     },
     "permissions": [
-        "storage"
+        "storage",
+        "tabs"
     ],
     "web_accessible_resources": [
         {


### PR DESCRIPTION
拡張機能のアイコンをクリックするとoptions.htmlを開くようにしました。

1. manifest.jsonにbackgroundを追加、actionを追加することでクリックさせられるように
2. icon_clicked.jsというファイルを作成してクリックされたときに開くように
3. permissionにtabsを追加して開くように権限を追加